### PR TITLE
Add scripts for building Android images and pushing kernel modules

### DIFF
--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Boot previously created boot image (prev-boot.img)
+
+# Usage: ./boot.sh
+
+if [ -f prev-boot.img ]; then
+    ORIG=$(readlink prev-boot.img)
+    echo "Booting $ORIG"
+    fastboot boot prev-boot.img
+fi

--- a/scripts/build_boot.sh
+++ b/scripts/build_boot.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Maintained by Hansem Ro (hansemro@outlook.com)
+
 # Build Android boot image (boot.img)
 #
 # Setup:

--- a/scripts/build_boot.sh
+++ b/scripts/build_boot.sh
@@ -46,16 +46,16 @@ build_boot_img() {
 }
 
 if [ "$1" == "help" ]; then
-    echo "./build_boot.sh               : build boot image with date and link" \
+    echo "./build_boot.sh            : build boot image with date and link" \
                                             "as prev-boot.img"
-    echo "./build_boot.sh help          : print this help message and exit"
-    echo "./build_boot.sh boot          : build boot image and boot with" \
+    echo "./build_boot.sh help       : print this help message and exit"
+    echo "./build_boot.sh boot       : build boot image and boot with" \
                                             "fastboot"
-    echo "./build_boot.sh just_boot     : just boot previously built image" \
+    echo "./build_boot.sh just_boot  : just boot previously built image" \
                                             "with fastboot"
-    echo "./build_boot.sh flash         : build boot image and flash boot" \
+    echo "./build_boot.sh flash      : build boot image and flash boot" \
                                             "partition with fastboot"
-    echo "./build_boot.sh just_flash    : just flash previously built image" \
+    echo "./build_boot.sh just_flash : just flash previously built image" \
                                             "with fastboot"
 elif [ "$1" == "just_boot" ]; then
     echo "Booting prev-boot.img with fastboot"

--- a/scripts/build_boot.sh
+++ b/scripts/build_boot.sh
@@ -26,11 +26,12 @@ BUILD_TIME=`date +"%Y-%m-%d-%H-%M"`
 build_boot_img() {
     cp ../arch/arm/boot/zImage ./$BUILD_TIME-zImage
     cp ../.config ./$BUILD_TIME-config
-    cp ../arch/arm/boot/dts/omap4-kc1.dtb ./
+    cp ../arch/arm/boot/dts/omap4-kc1.dtb ./$BUILD_TIME-omap4-kc1.dtb
 
     echo "Building $BUILD_TIME-boot.img"
 
-    mkbootimg --kernel ./$BUILD_TIME-zImage --dt omap4-kc1.dtb \
+    mkbootimg --kernel ./$BUILD_TIME-zImage \
+        --dt $BUILD_TIME-omap4-kc1.dtb \
         --pagesize 2048 --base 0x80000000 \
         --ramdisk_offset 0x01000000  --kernel_offset 0x00008000 \
         --second_offset 0x00f00000 --tags_offset 0x100 \

--- a/scripts/build_boot.sh
+++ b/scripts/build_boot.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Build Android boot image (boot.img)
+#
+# Setup:
+#   Create build directory inside Linux kernel
+#       $ mkdir linux/build
+#   Place this script to build directory
+#       $ cp build_boot.sh linux/build
+#
+# Uses mkbootimg from Cyanogenmod:android_system_core/mkbootimg
+# https://github.com/CyanogenMod/android_system_core.git
+#
+# Usage: ./build_boot.sh [OPTION]
+#
+# Available options:
+#   help        : print help message
+#   boot        : build and boot the image with fastboot
+#   flash       : build and flash the image with fastboot
+#   boot_prev   : just boot previously-built image with fastboot
+#   flash_prev  : just flash previously-built image with fastboot
+#
+
+BUILD_TIME=`date +"%Y-%m-%d-%H-%M"`
+
+build_boot_img() {
+    cp ../arch/arm/boot/zImage ./$BUILD_TIME-zImage
+    cp ../.config ./$BUILD_TIME-config
+    cp ../arch/arm/boot/dts/omap4-kc1.dtb ./
+
+    echo "Building $BUILD_TIME-boot.img"
+
+    mkbootimg --kernel ./$BUILD_TIME-zImage --dt omap4-kc1.dtb \
+        --pagesize 2048 --base 0x80000000 \
+        --ramdisk_offset 0x01000000  --kernel_offset 0x00008000 \
+        --second_offset 0x00f00000 --tags_offset 0x100 \
+        --cmdline "newbootargs console=ttyO2,115200n8 \
+        root=/dev/mmcblk0p9 mem=512M vram=24M omapfb.vram=0:8M \
+        omapdss.def_disp=lcd2 omapdss.debug=y" -o $BUILD_TIME-boot.img
+
+    echo "Successfully built $BUILD_TIME-boot.img"
+
+    # Create link to the most recently created boot image
+    echo "Linking $BUILD_TIME-boot.img as prev-boot.img"
+    rm prev-boot.img
+    ln -s $BUILD_TIME-boot.img prev-boot.img
+}
+
+if [ "$1" == "help" ]; then
+    echo "./build_boot.sh               : build boot image with date and link" \
+                                            "as prev-boot.img"
+    echo "./build_boot.sh help          : print this help message and exit"
+    echo "./build_boot.sh boot          : build boot image and boot with" \
+                                            "fastboot"
+    echo "./build_boot.sh just_boot     : just boot previously built image" \
+                                            "with fastboot"
+    echo "./build_boot.sh flash         : build boot image and flash boot" \
+                                            "partition with fastboot"
+    echo "./build_boot.sh just_flash    : just flash previously built image" \
+                                            "with fastboot"
+elif [ "$1" == "just_boot" ]; then
+    echo "Booting prev-boot.img with fastboot"
+    fastboot boot $BUILD_TIME-boot.img
+elif [ "$1" == "just_flash" ]; then
+    echo "Flashing prev-boot.img with fastboot"
+    fastboot flash boot $BUILD_TIME-boot.img
+else
+    if ! [ -f ../arch/arm/boot/zImage ]; then
+        echo "Error: missing zImage" >&2
+    else
+        build_boot_img
+        if [ "$1" == "boot" ]; then
+            echo "Booting $BUILD_TIME-boot.img with fastboot"
+            fastboot boot $BUILD_TIME-boot.img
+        elif [ "$1" == "flash" ]; then
+            echo "Flashing $BUILD_TIME-boot.img with fastboot"
+            fastboot flash boot $BUILD_TIME-boot.img
+        fi
+    fi
+fi

--- a/scripts/build_boot.sh
+++ b/scripts/build_boot.sh
@@ -8,7 +8,7 @@ BUILD_DIR=$PWD
 # Build Android boot image (boot.img)
 #
 # Setup:
-#   Create build directory inside Linux kernel
+#   Create build directory inside Linux kernel directory
 #       $ mkdir linux/build
 #   Place this script to build directory
 #       $ cp build_boot.sh linux/build

--- a/scripts/build_boot.sh
+++ b/scripts/build_boot.sh
@@ -53,16 +53,16 @@ if [ "$1" == "help" ]; then
     echo "./build_boot.sh help       : print this help message and exit"
     echo "./build_boot.sh boot       : build boot image and boot with" \
                                             "fastboot"
-    echo "./build_boot.sh just_boot  : just boot previously built image" \
+    echo "./build_boot.sh boot_prev  : just boot previously built image" \
                                             "with fastboot"
     echo "./build_boot.sh flash      : build boot image and flash boot" \
                                             "partition with fastboot"
-    echo "./build_boot.sh just_flash : just flash previously built image" \
+    echo "./build_boot.sh flash_prev : just flash previously built image" \
                                             "with fastboot"
-elif [ "$1" == "just_boot" ]; then
+elif [ "$1" == "boot_prev" ]; then
     echo "Booting prev-boot.img with fastboot"
     fastboot boot prev-boot.img
-elif [ "$1" == "just_flash" ]; then
+elif [ "$1" == "flash_prev" ]; then
     echo "Flashing prev-boot.img with fastboot"
     fastboot flash boot prev-boot.img
 else

--- a/scripts/build_boot.sh
+++ b/scripts/build_boot.sh
@@ -60,10 +60,10 @@ if [ "$1" == "help" ]; then
                                             "with fastboot"
 elif [ "$1" == "just_boot" ]; then
     echo "Booting prev-boot.img with fastboot"
-    fastboot boot $BUILD_TIME-boot.img
+    fastboot boot prev-boot.img
 elif [ "$1" == "just_flash" ]; then
     echo "Flashing prev-boot.img with fastboot"
-    fastboot flash boot $BUILD_TIME-boot.img
+    fastboot flash boot prev-boot.img
 else
     if ! [ -f ../arch/arm/boot/zImage ]; then
         echo "Error: missing zImage" >&2

--- a/scripts/build_boot.sh
+++ b/scripts/build_boot.sh
@@ -35,9 +35,7 @@ build_boot_img() {
         --pagesize 2048 --base 0x80000000 \
         --ramdisk_offset 0x01000000  --kernel_offset 0x00008000 \
         --second_offset 0x00f00000 --tags_offset 0x100 \
-        --cmdline "newbootargs console=ttyO2,115200n8 \
-        root=/dev/mmcblk0p9 mem=512M vram=24M omapfb.vram=0:8M \
-        omapdss.def_disp=lcd2 omapdss.debug=y" -o $BUILD_TIME-boot.img
+        --cmdline "root=/dev/mmcblk0p9" -o $BUILD_TIME-boot.img
 
     echo "Successfully built $BUILD_TIME-boot.img"
 

--- a/scripts/make-linux.sh
+++ b/scripts/make-linux.sh
@@ -6,6 +6,7 @@
 #   ./make-linux.sh         : build kernel + modules
 #   ./make-linux.sh clean   : cleanup kernel and modules
 #   ./make-linux.sh command : same as make ARCH=arm CROSS_COMPILE=... command
+#   ./make-linux.sh dtb     : build omap4-kc1.dtb
 
 # Make script inspired by Hector Martin
 # https://www.youtube.com/watch?v=x8f9-E_eP4M
@@ -41,7 +42,13 @@ function show_time () {
     echo "$day"d "$hour"h "$min"m "$sec"s
 }
 
-if [ "$1" == "clean" ]; then
+
+if [ "$1" == "help" ]; then
+    echo "./make-linux.sh         : build kernel + modules"
+    echo "./make-linux.sh clean   : cleanup kernel and modules"
+    echo "./make-linux.sh command : same as make ARCH=arm CROSS_COMPILE=... command"
+    echo "./make-linux.sh dtb     : build omap4-kc1.dtb"
+elif [ "$1" == "clean" ]; then
     $MK clean
     rm -rf arch/arm/boot/lib
     rm -rf arch/arm/boot/dts/*.dtb

--- a/scripts/push_modules.sh
+++ b/scripts/push_modules.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+LIN_VERSION=5.11.0+
+
+rm -rf ./$LIN_VERSION
+cp -r ../arch/arm/boot/lib/modules/$LIN_VERSION ./
+# adb shell mkdir /mnt
+# adb shell mount /dev/block/mmcblk0p13 /mnt
+# adb shell mount /dev/block/mmcblk0p9 /system
+adb shell mkdir -p /system/lib/modules/backup
+adb shell rm -rf /system/lib/modules/$LIN_VERSION
+adb push $LIN_VERSION/ /system/lib/modules/
+# adb shell umount /system

--- a/scripts/push_modules.sh
+++ b/scripts/push_modules.sh
@@ -1,5 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
+# Maintained by Hansem Ro (hansemro@outlook.com)
+
+# Push Linux modules via adb (while in recovery mode)
+#
+# Usage: ./push_modules.sh
+
+# Change LIN_VERSION to kernel version that shows up
+# at linux/arch/arm/boot/lin/modules/<version>
 LIN_VERSION=5.11.0+
 
 rm -rf ./$LIN_VERSION


### PR DESCRIPTION
Changes:
- `scripts/boot.sh`: Boot previously built Android boot image
- `scripts/build_boot.sh`: Build Android boot image with built kernel + device tree blob
- `scripts/push_modules.sh`: Push kernel modules to kindle fire in recovery mode
- `scripts/make-linux.sh`: Add comments on dtb option