### PR TITLE
Add battery, fuel gauge, and temperature sensor support to device tree

### DIFF
--- a/config/omap4-kc1.dts
+++ b/config/omap4-kc1.dts
@@ -30,6 +30,11 @@
 			max-brightness = <127>;
 		};
 	};
+
+	bat: battery {
+		compatible = "simple-battery";
+		/* Documentation/devicetree/bindings/power/supply/battery.yaml */
+	};
 };
 
 &omap4_pmx_core {
@@ -107,11 +112,6 @@
 	pinctrl-0 = <&i2c1_pins>;
 
 	clock-frequency = <400000>;
-
-	bat: battery {
-		compatible = "simple-battery";
-		/* Documentation/devicetree/bindings/power/supply/battery.yaml */
-	};
 
 	ti,bq27541@55 {
 		compatible = "ti,bq27541";

--- a/config/omap4-kc1.dts
+++ b/config/omap4-kc1.dts
@@ -151,6 +151,12 @@
 	pinctrl-0 = <&i2c4_pins>;
 
 	clock-frequency = <400000>;
+
+	tmp@48 {
+		compatible = "ti,tmp105";
+		reg = <0x48>;
+		status = "okay";
+	};
 };
 
 &mmc1 {

--- a/config/omap4-kc1.dts
+++ b/config/omap4-kc1.dts
@@ -108,6 +108,18 @@
 
 	clock-frequency = <400000>;
 
+	bat: battery {
+		compatible = "simple-battery";
+		/* Documentation/devicetree/bindings/power/supply/battery.yaml */
+	};
+
+	ti,bq27541@55 {
+		compatible = "ti,bq27541";
+		reg = <0x55>;
+		monitored-battery = <&bat>;
+		/* Documentation/devicetree/bindings/power/supply/bq27xxx.yaml */
+	};
+
 	twl: twl@48 {
 		reg = <0x48>;
 		/* IRQ# = 7 */


### PR DESCRIPTION
This pull requests merges changes from `dtb_dev` to `main` to bring support for battery fuel gauge and temperature sensor. Both of which work without device driver changes.

sysfs:
```
/sys/class/power_supply/bq27541-0
/sys/class/hwmon/hwmon2/
```

Comments:
- Battery properties (such as charge_full_design, technology, and others) were filled in despite them not being described in the device tree.